### PR TITLE
MDS-383 | Added cache id implementation

### DIFF
--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/ScopesService.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/ScopesService.scala
@@ -57,6 +57,9 @@ class ScopesService @Inject()(configuration: Configuration) {
     getFieldNames(authorizedDataItemsOnEndpoint)
   }
 
+  def getValidFieldsForCacheKey(scopes: List[String]): String =
+    scopes.flatMap(getScopeItemsKeys).distinct.reduce(_ + _)
+
   def getAccessibleEndpoints(scopes: List[String]): Iterable[String] = {
     val scopeKeys = scopes.flatMap(s => getScopeItemsKeys(s))
     apiConfig.endpoints

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/cache/CacheService.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/cache/CacheService.scala
@@ -16,7 +16,10 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache
 
+import java.util.UUID
+
 import javax.inject.Inject
+import org.joda.time.Interval
 import play.api.libs.json.Format
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.cache.{
@@ -32,16 +35,16 @@ class CacheService @Inject()(
 
   lazy val cacheEnabled: Boolean = conf.cacheEnabled
 
-  def get[T: Format](cacheId: String, fallbackFunction: => Future[T])(
+  def get[T: Format](cacheId: CacheIdBase, fallbackFunction: => Future[T])(
       implicit hc: HeaderCarrier): Future[T] = {
 
     if (cacheEnabled)
-      cachingClient.fetchAndGetEntry[T](cacheId, conf.key) flatMap {
+      cachingClient.fetchAndGetEntry[T](cacheId.id, conf.key) flatMap {
         case Some(value) =>
           Future.successful(value)
         case None =>
           fallbackFunction map { result =>
-            cachingClient.cache(cacheId, conf.key, result)
+            cachingClient.cache(cacheId.id, conf.key, result)
             result
           }
       } else {
@@ -49,4 +52,27 @@ class CacheService @Inject()(
     }
 
   }
+}
+
+// Cache ID implementations
+// This can then be concatenated for multiple scopes.
+// Example;
+// read:scope-1 =  [A, B, C]
+// read:scope-2 = [D, E, F]
+// The cache key (if two scopes alone) would be;
+// `id + from + to +  [A, B, C, D, E, F]` Or formatted to `id-from-to-ABCDEF`
+// The `fields` param is obtained with scopeService.getValidFieldsForCacheKey(scopes: List[String])
+
+trait CacheIdBase {
+  val id: String
+
+  override def toString: String = id
+}
+
+case class CacheId(matchId: UUID, interval: Interval, fields: String)
+    extends CacheIdBase {
+
+  lazy val id: String =
+    s"$matchId-${interval.getStart}-${interval.getEnd}-$fields"
+
 }

--- a/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/CacheServiceSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/CacheServiceSpec.scala
@@ -23,7 +23,10 @@ import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{Json, OFormat}
 import play.api.test.Helpers.running
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache.CacheService
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache.{
+  CacheIdBase,
+  CacheService
+}
 
 import scala.concurrent.Future
 
@@ -43,12 +46,14 @@ class CacheServiceSpec
 
       val app = new GuiceApplicationBuilder().build()
 
+      val cacheId = TestCacheId("foo")
+
       running(app) {
 
         val svc = app.injector.instanceOf[CacheService]
 
         svc
-          .get("foo", Future.successful(TestClass("bar")))
+          .get(cacheId, Future.successful(TestClass("bar")))
           .futureValue mustEqual TestClass("bar")
 
       }
@@ -58,24 +63,29 @@ class CacheServiceSpec
 
       val app = new GuiceApplicationBuilder().build()
 
+      val cacheId1 = TestCacheId("foo")
+      val cacheId2 = TestCacheId("bar")
+
       running(app) {
 
         val svc = app.injector.instanceOf[CacheService]
 
         svc
-          .get("foo", Future.successful(TestClass("bar")))
+          .get(cacheId1, Future.successful(TestClass("bar")))
           .futureValue mustEqual TestClass("bar")
         svc
-          .get("foo", Future.successful(TestClass("miss")))
+          .get(cacheId1, Future.successful(TestClass("miss")))
           .futureValue mustEqual TestClass("bar")
         svc
-          .get("bar", Future.successful(TestClass("miss")))
+          .get(cacheId2, Future.successful(TestClass("miss")))
           .futureValue mustEqual TestClass("miss")
 
       }
     }
   }
 }
+
+case class TestCacheId(id: String) extends CacheIdBase
 
 case class TestClass(param: String)
 

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/ScopesServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/ScopesServiceSpec.scala
@@ -70,6 +70,25 @@ class ScopesServiceSpec
                            "employer/employerDistrictNumber")
     }
 
+    "get valid data items keys for single scope" in {
+      val result =
+        scopesService.getValidFieldsForCacheKey(List(mockScope1))
+      result shouldBe "ABF"
+    }
+
+    "get valid data items keys for multiple scopes" in {
+      val result =
+        scopesService.getValidFieldsForCacheKey(List(mockScope1, mockScope2))
+      result shouldBe "ABFCDEG"
+    }
+
+    "get valid data items keys for multiple scopes including no match" in {
+      val result =
+        scopesService.getValidFieldsForCacheKey(
+          List(mockScope1, mockScope2, "not-exists"))
+      result shouldBe "ABFCDEG"
+    }
+
     "identity accesssible endpoints" in {
       val result = scopesService.getAccessibleEndpoints(List(mockScope3)).toList
       result.contains(mockEndpoint1) shouldBe true

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/cache/CacheServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/cache/CacheServiceSpec.scala
@@ -29,7 +29,10 @@ import uk.gov.hmrc.individualsbenefitsandcreditsapi.cache.{
   CacheConfiguration,
   ShortLivedCache
 }
-import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache.CacheService
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache.{
+  CacheIdBase,
+  CacheService
+}
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.SpecBase
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -41,7 +44,7 @@ class CacheServiceSpec
     with Matchers
     with BeforeAndAfterEach {
 
-  val cacheId = UUID.randomUUID().toString
+  val cacheId = TestCacheId("someid")
   val cachedValue = TestClass("cached value")
   val newValue = TestClass("new value")
 
@@ -65,7 +68,7 @@ class CacheServiceSpec
 
       given(
         mockClient.fetchAndGetEntry[TestClass](
-          eqTo(cacheId),
+          eqTo(cacheId.id),
           eqTo("individuals-benefits-and-credits"))(any()))
         .willReturn(Future.successful(Some(cachedValue)))
       await(cacheService.get[TestClass](cacheId, Future.successful(newValue))) shouldBe cachedValue
@@ -78,13 +81,13 @@ class CacheServiceSpec
 
       given(
         mockClient.fetchAndGetEntry[TestClass](
-          eqTo(cacheId),
+          eqTo(cacheId.id),
           eqTo("individuals-benefits-and-credits"))(any()))
         .willReturn(Future.successful(None))
 
       await(cacheService.get[TestClass](cacheId, Future.successful(newValue))) shouldBe newValue
       verify(mockClient).cache[TestClass](
-        eqTo(cacheId),
+        eqTo(cacheId.id),
         eqTo("individuals-benefits-and-credits"),
         eqTo(newValue))(any())
 
@@ -99,6 +102,8 @@ class CacheServiceSpec
     }
   }
 }
+
+case class TestCacheId(id: String) extends CacheIdBase
 
 case class TestClass(value: String)
 


### PR DESCRIPTION
**Design:**

Our handler pattern maps data items to scopes.
I.e. [A, B, C]
Where;
A = address line 1
B = address line 2
C = address line 3 etc
So the cache key can use the data item keys “[A, B, C]”

This can then be concatenated for multiple scopes.
Example;
read:scope-1 = [A, B, C]
read:scope-2 = [D, E, F]
The cache key (if two scopes alone) would be;
id + from + to + [A, B, C, D, E, F] Or formatted to id-from-to-ABCDEF