### PR TITLE
MDS-448 | Error Handling

### DIFF
--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnector.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnector.scala
@@ -25,19 +25,9 @@ import play.api.libs.json.Json
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.logging.Authorization
-import uk.gov.hmrc.http.{
-  BadRequestException,
-  HeaderCarrier,
-  HttpClient,
-  NotFoundException,
-  TooManyRequestException,
-  Upstream4xxResponse
-}
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, InternalServerException, JsValidationException, NotFoundException, TooManyRequestException, Upstream4xxResponse, Upstream5xxResponse}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.audit.AuditHelper
-import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.{
-  IfApplication,
-  IfApplications
-}
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.{IfApplication, IfApplications}
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -111,9 +101,17 @@ class IfConnector @Inject()(servicesConfig: ServicesConfig,
                          request: RequestHeader,
                          requestUrl: String)
                         (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[A]] = x.recoverWith {
+    case validationError: JsValidationException => {
+      auditHelper.auditIfApiFailure(correlationId, None, matchId, request, requestUrl, s"Error parsing IF response: ${validationError.errors}")
+      Future.failed(new InternalServerException("Something went wrong."))
+    }
     case notFound: NotFoundException => {
       auditHelper.auditIfApiFailure(correlationId, None, matchId, request, requestUrl, notFound.getMessage)
       Future.successful(Seq.empty)
+    }
+    case Upstream5xxResponse(msg, _, _, _) => {
+      auditHelper.auditIfApiFailure(correlationId, None, matchId, request, requestUrl, s"Internal Server error: $msg")
+      Future.failed(new InternalServerException("Something went wrong."))
     }
     case Upstream4xxResponse(msg, 429, _, _) => {
       Logger.warn(s"Integration Framework Rate limited: $msg")
@@ -122,11 +120,11 @@ class IfConnector @Inject()(servicesConfig: ServicesConfig,
     }
     case Upstream4xxResponse(msg, _, _, _) => {
       auditHelper.auditIfApiFailure(correlationId, None, matchId, request, requestUrl, msg)
-      Future.failed(new IllegalArgumentException(s"Integration Framework returned INVALID_REQUEST"))
+      Future.failed(new InternalServerException("Something went wrong."))
     }
     case e: Exception => {
       auditHelper.auditIfApiFailure(correlationId, None, matchId, request, requestUrl, e.getMessage)
-      Future.failed(e)
+      Future.failed(new InternalServerException("Something went wrong."))
     }
   }
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/ErrorResponses.scala
@@ -35,7 +35,7 @@ case class ErrorUnauthorized(errorMessage: String)
 case class ErrorInternalServer(errorMessage: String = "Failed to process request")
     extends ErrorResponse(INTERNAL_SERVER_ERROR,
                           "INTERNAL_SERVER_ERROR",
-                          "Failed to process request")
+                          message = errorMessage)
 case object ErrorNotFound
     extends ErrorResponse(NOT_FOUND,
                           "NOT_FOUND",

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/ErrorResponses.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/ErrorResponses.scala
@@ -32,7 +32,7 @@ case class ErrorInvalidRequest(errorMessage: String)
     extends ErrorResponse(BAD_REQUEST, "INVALID_REQUEST", errorMessage)
 case class ErrorUnauthorized(errorMessage: String)
     extends ErrorResponse(UNAUTHORIZED, "UNAUTHORIZED", errorMessage)
-case object ErrorInternalServer
+case class ErrorInternalServer(errorMessage: String = "Failed to process request")
     extends ErrorResponse(INTERNAL_SERVER_ERROR,
                           "INTERNAL_SERVER_ERROR",
                           "Failed to process request")

--- a/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/CommonControllerWithIfRequestSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/CommonControllerWithIfRequestSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
+
+import component.uk.gov.hmrc.individualsbenefitsandcreditsapi.stubs.{AuthStub, IfStub, IndividualsMatchingApiStub}
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import testUtils.TestHelpers
+
+trait CommonControllerWithIfRequestSpec extends CommonControllerSpec with TestHelpers {
+
+
+  val apps = createValidIfApplicationsMultiple
+  val invalidApplications = createInvalidIfApplications
+  val nino = "AB123456C"
+
+  scenario(s"user does not have valid scopes") {
+    Given("A valid auth token but invalid scopes")
+    AuthStub.willNotAuthorizePrivilegedAuthTokenNoScopes(authToken)
+
+    And("a valid record in the matching API")
+    IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
+
+    And("IF will return benefits and credits applications")
+    IfStub.searchBenefitsAndCredits(nino, fromDate, toDate, apps)
+
+
+    When(
+      s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
+    val response = invokeEndpoint(s"$serviceUrl/${endpoint}?matchId=$matchId&fromDate=$fromDate&toDate=$toDate")
+
+    Then("The response status should be 401")
+    response.code shouldBe UNAUTHORIZED
+    Json.parse(response.body) shouldBe Json.obj(
+      "code" -> "UNAUTHORIZED",
+      "message" ->"Insufficient Enrolments"
+    )
+  }
+
+  scenario(s"valid request but invalid IF response") {
+
+    Given("A valid auth token ")
+    AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+    And("a valid record in the matching API")
+    IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
+
+    And("IF will return invalid response")
+    IfStub.searchBenefitsAndCredits(nino, fromDate, toDate, invalidApplications)
+
+    When(
+      s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
+    val response = invokeEndpoint(s"$serviceUrl/${endpoint}?matchId=$matchId&fromDate=$fromDate&toDate=$toDate")
+
+    Then("The response status should be 500 with a generic error message")
+    response.code shouldBe INTERNAL_SERVER_ERROR
+    Json.parse(response.body) shouldBe Json.obj(
+      "code" -> "INTERNAL_SERVER_ERROR",
+      "message" -> "Something went wrong.")
+  }
+
+  scenario(s"IF returns an Internal Server Error") {
+
+    Given("A valid auth token ")
+    AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+    And("a valid record in the matching API")
+    IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
+
+    And("IF will return Internal Server Error")
+    IfStub.customResponse(nino, fromDate, toDate, INTERNAL_SERVER_ERROR, Json.obj("reason" -> "Server error"))
+
+    When(
+      s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
+    val response = invokeEndpoint(s"$serviceUrl/${endpoint}?matchId=$matchId&fromDate=$fromDate&toDate=$toDate")
+
+    Then("The response status should be 500 with a generic error message")
+    response.code shouldBe INTERNAL_SERVER_ERROR
+    Json.parse(response.body) shouldBe Json.obj(
+      "code" -> "INTERNAL_SERVER_ERROR",
+      "message" -> "Something went wrong.")
+  }
+
+  scenario(s"IF returns an Bad Request Error") {
+
+    Given("A valid auth token ")
+    AuthStub.willAuthorizePrivilegedAuthToken(authToken, rootScope)
+
+    And("a valid record in the matching API")
+    IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
+
+    And("IF will return Internal Server Error")
+    IfStub.customResponse(nino, fromDate, toDate, UNPROCESSABLE_ENTITY, Json.obj("reason" ->
+      "There are 1 or more unknown data items in the 'fields' query string"))
+
+    When(
+      s"I make a call to ${if (endpoint.isEmpty) "root" else endpoint} endpoint")
+    val response = invokeEndpoint(s"$serviceUrl/${endpoint}?matchId=$matchId&fromDate=$fromDate&toDate=$toDate")
+
+    Then("The response status should be 500 with a generic error message")
+    response.code shouldBe INTERNAL_SERVER_ERROR
+    Json.parse(response.body) shouldBe Json.obj(
+      "code" -> "INTERNAL_SERVER_ERROR",
+      "message" -> "Something went wrong.")
+  }
+}

--- a/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/LiveChildTaxCreditControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/LiveChildTaxCreditControllerSpec.scala
@@ -29,7 +29,7 @@ import scalaj.http.Http
 import testUtils.TestHelpers
 
 class LiveChildTaxCreditControllerSpec
-    extends CommonControllerSpec
+    extends CommonControllerWithIfRequestSpec
     with TestHelpers {
 
   val rootScope = List(
@@ -44,11 +44,9 @@ class LiveChildTaxCreditControllerSpec
 
   val endpoint = "child-tax-credit"
   val matchId = UUID.randomUUID()
-  val nino = "AB123456C"
   val fromDate = "2017-01-01"
   val toDate = "2017-09-25"
 
-  private val applications = createValidIfApplicationsMultiple
 
   feature("Live Child Tax Credit Controller") {
 
@@ -62,7 +60,7 @@ class LiveChildTaxCreditControllerSpec
       IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
 
       And("IF will return benefits and credits applications")
-      IfStub.searchBenefitsAndCredits(nino, fromDate, toDate, applications)
+      IfStub.searchBenefitsAndCredits(nino, fromDate, toDate, apps)
 
       When("I make a call to child-tax-credit endpoint")
       val response =

--- a/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/LiveRootControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/LiveRootControllerSpec.scala
@@ -18,11 +18,7 @@ package component.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
 import java.util.UUID
 
-import component.uk.gov.hmrc.individualsbenefitsandcreditsapi.stubs.{
-  AuthStub,
-  BaseSpec,
-  IndividualsMatchingApiStub
-}
+import component.uk.gov.hmrc.individualsbenefitsandcreditsapi.stubs.{AuthStub, BaseSpec, IfStub, IndividualsMatchingApiStub}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 
@@ -132,6 +128,26 @@ class LiveRootControllerSpec extends BaseSpec {
             "title" -> "Get Child Tax Credit details"
           )
         )
+      )
+    }
+
+    scenario(s"user does not have valid scopes") {
+      Given("A valid auth token but invalid scopes")
+      AuthStub.willNotAuthorizePrivilegedAuthTokenNoScopes(authToken)
+
+      And("a valid record in the matching API")
+      IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
+
+
+      When(
+        s"I make a call to root endpoint")
+      val response = invokeEndpoint(s"$serviceUrl/?matchId=$matchId")
+
+      Then("The response status should be 401")
+      response.code shouldBe UNAUTHORIZED
+      Json.parse(response.body) shouldBe Json.obj(
+        "code" -> "UNAUTHORIZED",
+        "message" ->"Insufficient Enrolments"
       )
     }
   }

--- a/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/LiveWorkingTaxCreditControllerSpec.scala
+++ b/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/LiveWorkingTaxCreditControllerSpec.scala
@@ -29,7 +29,7 @@ import scalaj.http.Http
 import testUtils.TestHelpers
 
 class LiveWorkingTaxCreditControllerSpec
-    extends CommonControllerSpec
+    extends CommonControllerWithIfRequestSpec
     with TestHelpers {
 
   val rootScope = List(
@@ -44,11 +44,8 @@ class LiveWorkingTaxCreditControllerSpec
 
   val matchId = UUID.randomUUID()
   val endpoint = "working-tax-credit"
-  val nino = "AB123456C"
   val fromDate = "2017-01-01"
   val toDate = "2017-09-25"
-
-  private val applications = createValidIfApplicationsMultiple
 
   feature("Live working tax credit route") {
 
@@ -61,7 +58,7 @@ class LiveWorkingTaxCreditControllerSpec
       IndividualsMatchingApiStub.hasMatchFor(matchId.toString, nino)
 
       And("IF will return benefits and credits applications")
-      IfStub.searchBenefitsAndCredits(nino, fromDate, toDate, applications)
+      IfStub.searchBenefitsAndCredits(nino, fromDate, toDate, apps)
 
       When("I make a call to working-tax-credit endpoint")
       val response =

--- a/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/stubs/AuthStub.scala
+++ b/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/stubs/AuthStub.scala
@@ -16,14 +16,7 @@
 
 package component.uk.gov.hmrc.individualsbenefitsandcreditsapi.stubs
 
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  aResponse,
-  equalTo,
-  equalToJson,
-  get,
-  post,
-  urlEqualTo
-}
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, equalTo, equalToJson, get, post, urlEqualTo}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import play.api.http.HeaderNames.AUTHORIZATION
 import play.api.http.{HeaderNames, Status}
@@ -104,6 +97,17 @@ object AuthStub extends MockHost(22000) {
             .withHeader(
               HeaderNames.WWW_AUTHENTICATE,
               """MDTP detail="Bearer token is missing or not authorized"""")))
+
+  def willNotAuthorizePrivilegedAuthTokenNoScopes(authBearerToken: String): StubMapping =
+    mock.register(
+      post(urlEqualTo("/auth/authorise"))
+        .withHeader(AUTHORIZATION, equalTo(authBearerToken))
+        .willReturn(
+          aResponse()
+            .withStatus(Status.UNAUTHORIZED)
+            .withHeader(
+              HeaderNames.WWW_AUTHENTICATE,
+              """MDTP detail="InsufficientEnrolments"""")))
 
   def willAuthorizeNinoWithAuthToken(nino: String, authBearerToken: String) =
     mock.register(

--- a/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/stubs/IfStub.scala
+++ b/test/component/uk/gov/hmrc/individualsbenefitsandcreditsapi/stubs/IfStub.scala
@@ -17,7 +17,7 @@
 package component.uk.gov.hmrc.individualsbenefitsandcreditsapi.stubs
 
 import com.github.tomakehurst.wiremock.client.WireMock._
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfApplications
 
@@ -34,6 +34,17 @@ object IfStub extends MockHost(22004) {
         .willReturn(aResponse()
           .withStatus(OK)
           .withBody(Json.toJson(ifApplications).toString())))
+
+  def customResponse(nino: String, fromDate: String,
+                     toDate: String, status: Int, response: JsValue) =
+    mock.register(
+      get(urlPathEqualTo(s"/individuals/tax-credits/nino/$nino"))
+        .withQueryParam("startDate", equalTo(fromDate))
+        .withQueryParam("endDate", equalTo(toDate))
+        .willReturn(
+          aResponse()
+            .withStatus(status)
+            .withBody(response.toString())))
 
   def enforceRateLimit(nino: String, fromDate: String, toDate: String): Unit =
     mock.register(

--- a/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnectorSpec.scala
@@ -17,14 +17,7 @@
 package it.uk.gov.hmrc.individualsbenefitsandcreditsapi.connectors
 
 import com.github.tomakehurst.wiremock.WireMockServer
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  aResponse,
-  configureFor,
-  equalTo,
-  get,
-  stubFor,
-  urlPathMatching
-}
+import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, configureFor, equalTo, get, stubFor, urlPathMatching}
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
@@ -36,12 +29,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import testUtils.{TestDates, TestHelpers}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.http.{
-  BadRequestException,
-  HeaderCarrier,
-  HttpClient,
-  Upstream5xxResponse
-}
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpClient, InternalServerException, Upstream5xxResponse}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.audit.AuditHelper
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.connectors.IfConnector
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
@@ -120,7 +108,7 @@ class IfConnectorSpec
           .withQueryParam("endDate", equalTo(endDate))
           .willReturn(aResponse().withStatus(500)))
 
-      intercept[Upstream5xxResponse] {
+      intercept[InternalServerException] {
         await(
           underTest.fetchTaxCredits(nino, interval, None, matchId)(
             hc,
@@ -144,7 +132,7 @@ class IfConnectorSpec
           .withQueryParam("endDate", equalTo(endDate))
           .willReturn(aResponse().withStatus(400)))
 
-      intercept[BadRequestException] {
+      intercept[InternalServerException] {
         await(
           underTest.fetchTaxCredits(nino, interval, None, matchId)(
             hc,

--- a/test/testUtils/TestHelpers.scala
+++ b/test/testUtils/TestHelpers.scala
@@ -56,34 +56,73 @@ trait TestHelpers {
                                           entitlementYTD = Some(22),
                                           paidYTD = Some(22))
 
-  def createValidIfApplications: IfApplications = {
+  val etcPayment = IfPayment(
+    periodStartDate = Some("2020-08-18"),
+    periodEndDate = Some("2020-08-18"),
+    startDate = Some("2020-08-18"),
+    endDate = Some("2020-08-18"),
+    status = Some("A"),
+    postedDate = Some("2020-08-18"),
+    nextDueDate = Some("2020-08-18"),
+    frequency = Some(1),
+    tcType = Some("ETC"),
+    amount = Some(22),
+    method = Some("R")
+  )
 
-    val ifPayments = Seq(
-      IfPayment(
-        periodStartDate = Some("2020-08-18"),
-        periodEndDate = Some("2020-08-18"),
-        startDate = Some("2020-08-18"),
-        endDate = Some("2020-08-18"),
-        status = Some("A"),
-        postedDate = Some("2020-08-18"),
-        nextDueDate = Some("2020-08-18"),
-        frequency = Some(1),
-        tcType = Some("ETC"),
-        amount = Some(22),
-        method = Some("R")
-      )
-    )
+  val iccPayment = IfPayment(
+    periodStartDate = Some("2020-08-17"),
+    periodEndDate = Some("2020-08-17"),
+    startDate = Some("2020-08-17"),
+    endDate = Some("2020-08-17"),
+    status = Some("A"),
+    postedDate = Some("2020-08-17"),
+    nextDueDate = Some("2020-08-17"),
+    frequency = Some(1),
+    tcType = Some("ICC"),
+    amount = Some(22),
+    method = Some("R")
+  )
 
-    val ifAwards = IfAward(
+  def createIfAward(wtc: IfWorkTaxCredit, ctc: IfChildTaxCredit, payments: Seq[IfPayment]):IfAward = {
+    IfAward(
       payProfCalcDate = Some("2020-08-18"),
       startDate = Some("2020-08-18"),
       endDate = Some("2020-08-18"),
       totalEntitlement = Some(22),
-      workTaxCredit = Some(ifWorkTaxCredit),
-      childTaxCredit = Some(ifChildTaxCredit),
+      workTaxCredit = Some(wtc),
+      childTaxCredit = Some(ctc),
       grossTaxYearAmount = Some(22),
-      payments = Some(ifPayments)
+      payments = Some(payments)
     )
+  }
+
+  def createValidIfApplications: IfApplications = {
+
+    val ifPayments = Seq(
+      etcPayment
+    )
+
+    val ifAwards = createIfAward(ifWorkTaxCredit, ifChildTaxCredit, ifPayments)
+
+    val application = IfApplication(
+      id = Some(22),
+      ceasedDate = Some("2020-08-18"),
+      entStartDate = Some("2020-08-18"),
+      entEndDate = Some("2020-08-18"),
+      awards = Some(Seq(ifAwards))
+    )
+
+    IfApplications(Seq(application))
+  }
+
+  def createInvalidIfApplications: IfApplications = {
+
+    val ifPayments = Seq(
+      etcPayment.copy(startDate = Some("Invalid date"))
+    )
+
+    val ifAwards = createIfAward(ifWorkTaxCredit, ifChildTaxCredit, ifPayments)
 
     val application = IfApplication(
       id = Some(22),
@@ -97,56 +136,13 @@ trait TestHelpers {
   }
 
   def createValidIfApplicationsMultiple: IfApplications = {
-    val ifWorkTaxCredit = IfWorkTaxCredit(amount = Some(22),
-                                          entitlementYTD = Some(22),
-                                          paidYTD = Some(22))
-
-    val ifChildTaxCredit = IfChildTaxCredit(childCareAmount = Some(22),
-                                            ctcChildAmount = Some(22),
-                                            familyAmount = Some(22),
-                                            babyAmount = Some(22),
-                                            entitlementYTD = Some(22),
-                                            paidYTD = Some(22))
 
     val ifPayments = Seq(
-      IfPayment(
-        periodStartDate = Some("2020-08-18"),
-        periodEndDate = Some("2020-08-18"),
-        startDate = Some("2020-08-18"),
-        endDate = Some("2020-08-18"),
-        status = Some("A"),
-        postedDate = Some("2020-08-18"),
-        nextDueDate = Some("2020-08-18"),
-        frequency = Some(1),
-        tcType = Some("ETC"),
-        amount = Some(22),
-        method = Some("R")
-      ),
-      IfPayment(
-        periodStartDate = Some("2020-08-17"),
-        periodEndDate = Some("2020-08-17"),
-        startDate = Some("2020-08-17"),
-        endDate = Some("2020-08-17"),
-        status = Some("A"),
-        postedDate = Some("2020-08-17"),
-        nextDueDate = Some("2020-08-17"),
-        frequency = Some(1),
-        tcType = Some("ICC"),
-        amount = Some(22),
-        method = Some("R")
-      )
+      etcPayment,
+      iccPayment
     )
 
-    val ifAwards = IfAward(
-      payProfCalcDate = Some("2020-08-18"),
-      startDate = Some("2020-08-18"),
-      endDate = Some("2020-08-18"),
-      totalEntitlement = Some(22),
-      workTaxCredit = Some(ifWorkTaxCredit),
-      childTaxCredit = Some(ifChildTaxCredit),
-      grossTaxYearAmount = Some(22),
-      payments = Some(ifPayments)
-    )
+    val ifAwards = createIfAward(ifWorkTaxCredit, ifChildTaxCredit, ifPayments)
 
     val application = IfApplication(id = Some(22),
                                     ceasedDate = Some("2020-08-18"),


### PR DESCRIPTION
Updated the error handling so errors are not passed from IF to the user... any 4xxs or 5xxs will get logged and audited, but the user receive an Internal Server Error - "Something went wrong."

Error handling added to cover a lack of valid scopes, instead of returning one of the invalid scopes.

Added a generic, catch-all error ("Something went wrong.")