### PR TITLE
Automatic Trivial Parsers

### DIFF
--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcApplication.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcApplication.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits
 
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 import play.api.libs.functional.syntax._
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfApplication
 
@@ -30,14 +30,5 @@ object CtcApplication {
     )
   }
 
-  implicit val applicationFormat: Format[CtcApplication] = Format(
-    (
-      (JsPath \ "id").readNullable[Double] and
-        (JsPath \ "awards").read[Seq[CtcAward]]
-    )(CtcApplication.apply _),
-    (
-      (JsPath \ "id").writeNullable[Double] and
-        (JsPath \ "awards").write[Seq[CtcAward]]
-    )(unlift(CtcApplication.unapply))
-  )
+  implicit val applicationFormat: Format[CtcApplication] = Json.format[CtcApplication]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcAward.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits
 
 import org.joda.time.LocalDate
 import uk.gov.hmrc.http.controllers.RestFormats.localDateFormats
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 import play.api.libs.functional.syntax._
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfAward
 
@@ -39,18 +39,5 @@ object CtcAward {
     )
   }
 
-  implicit val awardFormat: Format[CtcAward] = Format(
-    (
-      (JsPath \ "payProfCalcDate").readNullable[LocalDate] and
-      (JsPath \ "totalEntitlement").readNullable[Double] and
-      (JsPath \ "childTaxCredit").readNullable[CtcChildTaxCredit] and
-      (JsPath \ "payments").readNullable[Seq[CtcPayment]]
-    )(CtcAward.apply _),
-    (
-      (JsPath \ "payProfCalcDate").writeNullable[LocalDate] and
-      (JsPath \ "totalEntitlement").writeNullable[Double] and
-      (JsPath \ "childTaxCredit").writeNullable[CtcChildTaxCredit] and
-      (JsPath \ "payments").writeNullable[Seq[CtcPayment]]
-    )(unlift(CtcAward.unapply))
-  )
+  implicit val awardFormat: Format[CtcAward] = Json.format[CtcAward]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcChildTaxCredit.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcChildTaxCredit.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits
 
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfChildTaxCredit
 
 case class CtcChildTaxCredit(
@@ -39,20 +39,5 @@ object CtcChildTaxCredit {
     )
   }
 
-  implicit val childTaxCreditFormat: Format[CtcChildTaxCredit] = Format(
-    (
-      (JsPath \ "childCareAmount").readNullable[Double] and
-        (JsPath \ "ctcChildAmount").readNullable[Double] and
-        (JsPath \ "familyAmount").readNullable[Double] and
-        (JsPath \ "babyAmount").readNullable[Double] and
-        (JsPath \ "paidYTD").readNullable[Double]
-    )(CtcChildTaxCredit.apply _),
-    (
-      (JsPath \ "childCareAmount").writeNullable[Double] and
-        (JsPath \ "ctcChildAmount").writeNullable[Double] and
-        (JsPath \ "familyAmount").writeNullable[Double] and
-        (JsPath \ "babyAmount").writeNullable[Double] and
-        (JsPath \ "paidYTD").writeNullable[Double]
-    )(unlift(CtcChildTaxCredit.unapply))
-  )
+  implicit val childTaxCreditFormat: Format[CtcChildTaxCredit] = Json.format[CtcChildTaxCredit]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcPayment.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits
 import org.joda.time.LocalDate
 import uk.gov.hmrc.http.controllers.RestFormats.localDateFormats
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfPayment
 
 case class CtcPayment(
@@ -43,22 +43,5 @@ object CtcPayment {
     )
   }
 
-  implicit val paymentFormat: Format[CtcPayment] = Format(
-    (
-      (JsPath \ "startDate").readNullable[LocalDate] and
-        (JsPath \ "endDate").readNullable[LocalDate] and
-        (JsPath \ "postedDate").readNullable[LocalDate] and
-        (JsPath \ "frequency").readNullable[Int] and
-        (JsPath \ "tcType").readNullable[String] and
-        (JsPath \ "amount").readNullable[Double]
-    )(CtcPayment.apply _),
-    (
-      (JsPath \ "startDate").writeNullable[LocalDate] and
-        (JsPath \ "endDate").writeNullable[LocalDate] and
-        (JsPath \ "postedDate").writeNullable[LocalDate] and
-        (JsPath \ "frequency").writeNullable[Int] and
-        (JsPath \ "tcType").writeNullable[String] and
-        (JsPath \ "amount").writeNullable[Double]
-    )(unlift(CtcPayment.unapply))
-  )
+  implicit val paymentFormat: Format[CtcPayment] = Json.format[CtcPayment]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfApplication.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfApplication.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframewor
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads.pattern
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 
 case class IfApplication(id: Option[Double],
                          ceasedDate: Option[String],
@@ -39,12 +39,6 @@ object IfApplication extends PatternsAndValidators {
           .readNullable[String](pattern(datePattern, "invalid date")) and
         (JsPath \ "awards").readNullable[Seq[IfAward]]
     )(IfApplication.apply _),
-    (
-      (JsPath \ "id").writeNullable[Double] and
-        (JsPath \ "ceasedDate").writeNullable[String] and
-        (JsPath \ "entStartDate").writeNullable[String] and
-        (JsPath \ "entEndDate").writeNullable[String] and
-        (JsPath \ "awards").writeNullable[Seq[IfAward]]
-    )(unlift(IfApplication.unapply))
+    Json.writes[IfApplication]
   )
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfApplications.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfApplications.scala
@@ -16,17 +16,10 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework
 
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 
 case class IfApplications(applications: Seq[IfApplication])
 
 object IfApplications {
-  implicit val applicationsFormat: Format[IfApplications] = Format(
-    (JsPath \ "applications")
-      .read[Seq[IfApplication]]
-      .map(IfApplications.apply),
-    (JsPath \ "applications")
-      .write[Seq[IfApplication]]
-      .contramap(_.applications)
-  )
+  implicit val applicationsFormat: Format[IfApplications] = Json.format[IfApplications]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfAward.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframewor
 
 import play.api.libs.functional.syntax._
 import play.api.libs.json.Reads.pattern
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 
 case class IfAward(
     payProfCalcDate: Option[String],
@@ -49,15 +49,6 @@ object IfAward extends PatternsAndValidators {
           .readNullable[Double](paymentAmountValidator) and
         (JsPath \ "payments").readNullable[Seq[IfPayment]]
     )(IfAward.apply _),
-    (
-      (JsPath \ "payProfCalcDate").writeNullable[String] and
-        (JsPath \ "startDate").writeNullable[String] and
-        (JsPath \ "endDate").writeNullable[String] and
-        (JsPath \ "totalEntitlement").writeNullable[Double] and
-        (JsPath \ "workingTaxCredit").writeNullable[IfWorkTaxCredit] and
-        (JsPath \ "childTaxCredit").writeNullable[IfChildTaxCredit] and
-        (JsPath \ "grossTaxYearAmount").writeNullable[Double] and
-        (JsPath \ "payments").writeNullable[Seq[IfPayment]]
-    )(unlift(IfAward.unapply))
+    Json.writes[IfAward]
   )
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfAward.scala
@@ -25,7 +25,7 @@ case class IfAward(
     startDate: Option[String],
     endDate: Option[String],
     totalEntitlement: Option[Double],
-    workTaxCredit: Option[IfWorkTaxCredit],
+    workingTaxCredit: Option[IfWorkTaxCredit],
     childTaxCredit: Option[IfChildTaxCredit],
     grossTaxYearAmount: Option[Double],
     payments: Option[Seq[IfPayment]]

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfChildTaxCredit.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfChildTaxCredit.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework
 
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 
 case class IfChildTaxCredit(
     childCareAmount: Option[Double],
@@ -43,13 +43,6 @@ object IfChildTaxCredit extends PatternsAndValidators {
           .readNullable[Double](paymentAmountValidator) and
         (JsPath \ "paidYTD").readNullable[Double](paymentAmountValidator)
     )(IfChildTaxCredit.apply _),
-    (
-      (JsPath \ "childCareAmount").writeNullable[Double] and
-        (JsPath \ "ctcChildAmount").writeNullable[Double] and
-        (JsPath \ "familyAmount").writeNullable[Double] and
-        (JsPath \ "babyAmount").writeNullable[Double] and
-        (JsPath \ "entitlementYTD").writeNullable[Double] and
-        (JsPath \ "paidYTD").writeNullable[Double]
-    )(unlift(IfChildTaxCredit.unapply))
+    Json.writes[IfChildTaxCredit]
   )
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfPayment.scala
@@ -35,33 +35,19 @@ case class IfPayment(
                      )
 
 object IfPayment extends PatternsAndValidators {
-
   implicit val paymentsFormat: Format[IfPayment] = Format(
     (
       (JsPath \ "periodStartDate").readNullable[String](pattern(datePattern, "invalid date")) and
-      (JsPath \ "periodEndDate").readNullable[String](pattern(datePattern, "invalid date")) and
-      (JsPath \ "startDate").readNullable[String](pattern(datePattern, "invalid date")) and
-      (JsPath \ "endDate").readNullable[String](pattern(datePattern, "invalid date")) and
-      (JsPath \ "status").readNullable[String](pattern(statusPattern, "invalid status")) and
-      (JsPath \ "postedDate").readNullable[String](pattern(datePattern, "invalid date")) and
-      (JsPath \ "nextDueDate").readNullable[String](pattern(datePattern, "invalid date")) and
-      (JsPath \ "frequency").readNullable[Int](min[Int](1).keepAnd(max[Int](999))) and
-      (JsPath \ "tcType").readNullable[String](pattern(tcTypePattern, "invalid tc type")) and
-      (JsPath \ "amount").readNullable[Double](paymentAmountValidator) and
-      (JsPath \ "method").readNullable[String](pattern(methodPattern, "invalid method"))
+        (JsPath \ "periodEndDate").readNullable[String](pattern(datePattern, "invalid date")) and
+        (JsPath \ "startDate").readNullable[String](pattern(datePattern, "invalid date")) and
+        (JsPath \ "endDate").readNullable[String](pattern(datePattern, "invalid date")) and
+        (JsPath \ "status").readNullable[String](pattern(statusPattern, "invalid status")) and
+        (JsPath \ "postedDate").readNullable[String](pattern(datePattern, "invalid date")) and
+        (JsPath \ "nextDueDate").readNullable[String](pattern(datePattern, "invalid date")) and
+        (JsPath \ "frequency").readNullable[Int](min[Int](1).keepAnd(max[Int](999))) and
+        (JsPath \ "tcType").readNullable[String](pattern(tcTypePattern, "invalid tc type")) and
+        (JsPath \ "amount").readNullable[Double](paymentAmountValidator) and
+        (JsPath \ "method").readNullable[String](pattern(methodPattern, "invalid method"))
     )(IfPayment.apply _),
-    (
-      (JsPath \ "periodStartDate").writeNullable[String] and
-        (JsPath \ "periodEndDate").writeNullable[String] and
-        (JsPath \ "startDate").writeNullable[String] and
-        (JsPath \ "endDate").writeNullable[String] and
-        (JsPath \ "status").writeNullable[String] and
-        (JsPath \ "postedDate").writeNullable[String] and
-        (JsPath \ "nextDueDate").writeNullable[String] and
-        (JsPath \ "frequency").writeNullable[Int] and
-        (JsPath \ "tcType").writeNullable[String] and
-        (JsPath \ "amount").writeNullable[Double] and
-        (JsPath \ "method").writeNullable[String]
-      )(unlift(IfPayment.unapply))
-  )
+    Json.writes[IfPayment])
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfWorkTaxCredit.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/integrationframework/IfWorkTaxCredit.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework
 
 import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, JsPath, Json}
 
 case class IfWorkTaxCredit(amount: Option[Double],
                            entitlementYTD: Option[Double],
@@ -32,10 +32,6 @@ object IfWorkTaxCredit extends PatternsAndValidators {
           .readNullable[Double](paymentAmountValidator) and
         (JsPath \ "paidYTD").readNullable[Double](paymentAmountValidator)
     )(IfWorkTaxCredit.apply _),
-    (
-      (JsPath \ "amount").writeNullable[Double] and
-        (JsPath \ "entitlementYTD").writeNullable[Double] and
-        (JsPath \ "paidYTD").writeNullable[Double]
-    )(unlift(IfWorkTaxCredit.unapply))
+    Json.writes[IfWorkTaxCredit]
   )
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcApplication.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcApplication.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
-import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfApplication
 
 case class WtcApplication(id: Option[Double], awards: Seq[WtcAward])
@@ -31,14 +30,5 @@ object WtcApplication {
     )
   }
 
-  implicit val applicationFormat: Format[WtcApplication] = Format(
-    (
-      (JsPath \ "id").readNullable[Double] and
-        (JsPath \ "awards").read[Seq[WtcAward]]
-    )(WtcApplication.apply _),
-    (
-      (JsPath \ "id").writeNullable[Double] and
-        (JsPath \ "awards").write[Seq[WtcAward]]
-    )(unlift(WtcApplication.unapply))
-  )
+  implicit val applicationFormat: Format[WtcApplication] = Json.format[WtcApplication]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
@@ -33,7 +33,7 @@ case class WtcAward(
 object WtcAward {
   def create(ifAward: IfAward) = {
 
-    val wtc = ifAward.workTaxCredit.map(WtcWorkingTaxCredit.create)
+    val wtc = ifAward.workingTaxCredit.map(WtcWorkingTaxCredit.create)
     val ctc = ifAward.childTaxCredit.map(WtcChildTaxCredit.create)
 
     WtcAward(

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
@@ -17,9 +17,9 @@
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
 import org.joda.time.LocalDate
+// Required for JodaDate parsers to function
 import uk.gov.hmrc.http.controllers.RestFormats.localDateFormats
-import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfAward
 
 case class WtcAward(
@@ -45,20 +45,5 @@ object WtcAward {
     )
   }
 
-  implicit val awardFormat: Format[WtcAward] = Format(
-    (
-      (JsPath \ "payProfCalcDate").readNullable[LocalDate] and
-      (JsPath \ "totalEntitlement").readNullable[Double] and
-      (JsPath \ "workingTaxCredit").readNullable[WtcWorkingTaxCredit] and
-      (JsPath \ "childTaxCredit").readNullable[WtcChildTaxCredit] and
-      (JsPath \ "payments").readNullable[Seq[WtcPayment]]
-    )(WtcAward.apply _),
-    (
-      (JsPath \ "payProfCalcDate").writeNullable[LocalDate] and
-      (JsPath \ "totalEntitlement").writeNullable[Double] and
-      (JsPath \ "workingTaxCredit").writeNullable[WtcWorkingTaxCredit] and
-      (JsPath \ "childTaxCredit").writeNullable[WtcChildTaxCredit] and
-      (JsPath \ "payments").writeNullable[Seq[WtcPayment]]
-    )(unlift(WtcAward.unapply))
-  )
+  implicit val awardFormat: Format[WtcAward] = Json.format[WtcAward]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcChildTaxCredit.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcChildTaxCredit.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfChildTaxCredit
 
 case class WtcChildTaxCredit(childCareAmount: Option[Double])
@@ -27,10 +27,5 @@ object WtcChildTaxCredit {
     WtcChildTaxCredit(ifChildTaxTaxCredit.childCareAmount)
   }
 
-  implicit val childTaxCreditFormat: Format[WtcChildTaxCredit] = Format(
-    (JsPath \ "childCareAmount").readNullable[Double].map(WtcChildTaxCredit(_)),
-    (JsPath \ "childCareAmount")
-      .writeNullable[Double]
-      .contramap(_.childCareAmount)
-  )
+  implicit val childTaxCreditFormat: Format[WtcChildTaxCredit] = Json.format[WtcChildTaxCredit]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcPayment.scala
@@ -17,10 +17,8 @@
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
 import org.joda.time.LocalDate
-import play.api.libs.functional.syntax._
-import play.api.libs.json.Format.GenericFormat
-import play.api.libs.json.{Format, JsPath}
 import uk.gov.hmrc.http.controllers.RestFormats.localDateFormats
+import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfPayment
 
 case class WtcPayment(
@@ -44,22 +42,5 @@ object WtcPayment {
     )
   }
 
-  implicit val paymentFormat: Format[WtcPayment] = Format(
-    (
-      (JsPath \ "startDate").readNullable[LocalDate] and
-        (JsPath \ "endDate").readNullable[LocalDate] and
-        (JsPath \ "postedDate").readNullable[LocalDate] and
-        (JsPath \ "frequency").readNullable[Int] and
-        (JsPath \ "tcType").readNullable[String] and
-        (JsPath \ "amount").readNullable[Double]
-    )(WtcPayment.apply _),
-    (
-      (JsPath \ "startDate").writeNullable[LocalDate] and
-        (JsPath \ "endDate").writeNullable[LocalDate] and
-        (JsPath \ "postedDate").writeNullable[LocalDate] and
-        (JsPath \ "frequency").writeNullable[Int] and
-        (JsPath \ "tcType").writeNullable[String] and
-        (JsPath \ "amount").writeNullable[Double]
-    )(unlift(WtcPayment.unapply))
-  )
+  implicit val paymentFormat: Format[WtcPayment] = Json.format[WtcPayment]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcWorkingTaxCredit.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcWorkingTaxCredit.scala
@@ -16,8 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
-import play.api.libs.functional.syntax._
-import play.api.libs.json.{Format, JsPath}
+import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfWorkTaxCredit
 
 case class WtcWorkingTaxCredit(amount: Option[Double], paidYTD: Option[Double])
@@ -28,14 +27,5 @@ object WtcWorkingTaxCredit {
     WtcWorkingTaxCredit(ifWorkTaxCredit.amount, ifWorkTaxCredit.paidYTD)
   }
 
-  implicit val workingTaxCreditFormat: Format[WtcWorkingTaxCredit] = Format(
-    (
-      (JsPath \ "amount").readNullable[Double] and
-        (JsPath \ "paidYTD").readNullable[Double]
-    )(WtcWorkingTaxCredit.apply _),
-    (
-      (JsPath \ "amount").writeNullable[Double] and
-        (JsPath \ "paidYTD").writeNullable[Double]
-    )(unlift(WtcWorkingTaxCredit.unapply))
-  )
+  implicit val workingTaxCreditFormat: Format[WtcWorkingTaxCredit] = Json.format[WtcWorkingTaxCredit]
 }

--- a/test/testUtils/TestHelpers.scala
+++ b/test/testUtils/TestHelpers.scala
@@ -90,7 +90,7 @@ trait TestHelpers {
       startDate = Some("2020-08-18"),
       endDate = Some("2020-08-18"),
       totalEntitlement = Some(22),
-      workTaxCredit = Some(wtc),
+      workingTaxCredit = Some(wtc),
       childTaxCredit = Some(ctc),
       grossTaxYearAmount = Some(22),
       payments = Some(payments)


### PR DESCRIPTION
This project (like many other individuals-* APIs) suffers from a ton of repetition.

One of the biggest sources of it is less than optimal usage of Scala JSON combinators:

https://www.playframework.com/documentation/2.8.x/ScalaJsonCombinators
https://www.playframework.com/documentation/2.8.x/ScalaJsonAutomated

Implementing a custom `Writes` doesn't necessarily force implementing custom reads (and vice versa), but here it seems every single field was implemented manually (which is a little error prone as seen in the first workingTaxCredits commit).

This PR aims to get rid of trivial writes (the constant readNullable/writeNullable are unnecessary - as seen in the second documentation link, it's done automatically for the Option[] type).