### PR TITLE
DLS-10099: Play 3.0 Upgrade

### DIFF
--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnector.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnector.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.connectors
 
-import org.joda.time.Interval
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import play.api.Logger
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.domain.Nino
@@ -47,8 +47,8 @@ class IfConnector @Inject()(servicesConfig: ServicesConfig, http: HttpClient, va
     ec: ExecutionContext): Future[Seq[IfApplication]] = {
 
     val endpoint = "IfConnector::fetchTaxCredits"
-    val startDate = interval.getStart.toLocalDate
-    val endDate = interval.getEnd.toLocalDate
+    val startDate = interval.from.toLocalDate
+    val endDate = interval.to.toLocalDate
 
     val url = s"$serviceUrl/individuals/tax-credits/nino/$nino?" +
       s"startDate=$startDate&endDate=$endDate${filter.map(f => s"&fields=$f").getOrElse("")}"

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/APIDocumentationController.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/APIDocumentationController.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import controllers.Assets
 import play.api.Configuration
 import play.api.mvc.{Action, AnyContent, ControllerComponents}

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditController.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditController.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import org.joda.time.Interval
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import play.api.hal.Hal._
 import play.api.hal.HalLink
 import play.api.libs.json.Json
@@ -53,9 +53,7 @@ class ChildTaxCreditController @Inject()(
             applications => {
               val selfLink = HalLink(
                 "self",
-                urlWithInterval(
-                  s"/individuals/benefits-and-credits/child-tax-credits?matchId=$matchId",
-                  interval.getStart))
+                urlWithInterval(s"/individuals/benefits-and-credits/child-tax-credits?matchId=$matchId", interval.from))
               val response =
                 Json.obj("applications" -> Json.toJson(applications))
 

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/CommonController.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/CommonController.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import org.joda.time.DateTime
 import play.api.Logger
 import play.api.mvc.{ControllerComponents, Request, RequestHeader, Result}
 import uk.gov.hmrc.auth.core.{AuthorisationException, InsufficientEnrolments}
@@ -26,6 +25,7 @@ import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains._
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Dates.toFormattedLocalDate
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.time.LocalDateTime
 import javax.inject.Inject
 
 abstract class CommonController @Inject()(
@@ -37,7 +37,7 @@ abstract class CommonController @Inject()(
   private def getQueryParam[T](name: String)(implicit request: Request[T]) =
     request.queryString.get(name).flatMap(_.headOption)
 
-  private[controllers] def urlWithInterval[T](url: String, fromDate: DateTime)(implicit request: Request[T]) = {
+  private[controllers] def urlWithInterval[T](url: String, fromDate: LocalDateTime)(implicit request: Request[T]) = {
     val urlWithFromDate = s"$url&fromDate=${toFormattedLocalDate(fromDate)}"
     getQueryParam("toDate") map (toDate => s"$urlWithFromDate&toDate=$toDate") getOrElse urlWithFromDate
   }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditController.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditController.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import org.joda.time.Interval
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import play.api.hal.Hal._
 import play.api.hal.HalLink
 import play.api.libs.json.Json
@@ -55,7 +55,7 @@ class WorkingTaxCreditController @Inject()(
                 "self",
                 urlWithInterval(
                   s"/individuals/benefits-and-credits/working-tax-credits?matchId=$matchId",
-                  interval.getStart))
+                  interval.from))
               val response =
                 Json.obj("applications" -> Json.toJson(applications))
 

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/Individual.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/Individual.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.domain.Nino
 
 import java.util.UUID

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcAward.scala
@@ -16,9 +16,8 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.http.controllers.RestFormats
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfAward
 
 case class CtcAward(
@@ -39,6 +38,6 @@ object CtcAward {
         .map(_.map(CtcPayment.create))
     )
 
-  implicit val dateFormat: Format[LocalDate] = RestFormats.localDateFormats
+  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val awardFormat: Format[CtcAward] = Json.format[CtcAward]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcAward.scala
@@ -38,6 +38,5 @@ object CtcAward {
         .map(_.map(CtcPayment.create))
     )
 
-  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val awardFormat: Format[CtcAward] = Json.format[CtcAward]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcPayment.scala
@@ -40,6 +40,5 @@ object CtcPayment {
       ifPayment.amount
     )
 
-  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val paymentFormat: Format[CtcPayment] = Json.format[CtcPayment]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/childtaxcredits/CtcPayment.scala
@@ -16,9 +16,8 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.http.controllers.RestFormats
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfPayment
 
 case class CtcPayment(
@@ -41,6 +40,6 @@ object CtcPayment {
       ifPayment.amount
     )
 
-  implicit val dateFormat: Format[LocalDate] = RestFormats.localDateFormats
+  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val paymentFormat: Format[CtcPayment] = Json.format[CtcPayment]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
@@ -16,9 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
-import org.joda.time.LocalDate
-import uk.gov.hmrc.http.controllers.RestFormats
-// Required for JodaDate parsers to function
+import java.time.LocalDate
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfAward
 
@@ -47,6 +45,6 @@ object WtcAward {
     )
   }
 
-  implicit val dateFormat: Format[LocalDate] = RestFormats.localDateFormats
+  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val awardFormat: Format[WtcAward] = Json.format[WtcAward]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcAward.scala
@@ -45,6 +45,5 @@ object WtcAward {
     )
   }
 
-  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val awardFormat: Format[WtcAward] = Json.format[WtcAward]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcPayment.scala
@@ -40,6 +40,5 @@ object WtcPayment {
       ifPayment.amount
     )
 
-  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val paymentFormat: Format[WtcPayment] = Json.format[WtcPayment]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcPayment.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/domains/workingtaxcredits/WtcPayment.scala
@@ -16,9 +16,8 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.http.controllers.RestFormats
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfPayment
 
 case class WtcPayment(
@@ -41,6 +40,6 @@ object WtcPayment {
       ifPayment.amount
     )
 
-  implicit val dateFormat: Format[LocalDate] = RestFormats.localDateFormats
+  implicit val dateFormat: Format[LocalDate] = Json.format[LocalDate]
   implicit val paymentFormat: Format[WtcPayment] = Json.format[WtcPayment]
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/TaxCreditsService.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/TaxCreditsService.scala
@@ -16,7 +16,7 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.services
 
-import org.joda.time.Interval
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import play.api.mvc.RequestHeader
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.connectors.{IfConnector, IndividualsMatchingApiConnector}

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/cache/CacheService.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/cache/CacheService.scala
@@ -16,9 +16,9 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache
 
-import org.joda.time.Interval
 import play.api.libs.json.Format
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.cache.{CacheRepository, CacheRepositoryConfiguration}
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 
 import java.util.UUID
 import javax.inject.Inject
@@ -63,6 +63,6 @@ trait CacheIdBase {
 case class CacheId(matchId: UUID, interval: Interval, fields: String) extends CacheIdBase {
 
   lazy val id: String =
-    s"$matchId-${interval.getStart}-${interval.getEnd}-$fields"
+    s"$matchId-${interval.from}-${interval.to}-$fields"
 
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/Dates.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/Dates.scala
@@ -16,21 +16,24 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.utils
 
-import org.joda.time.{DateTime, Interval, LocalDate}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.ValidationException
+
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, LocalDateTime, LocalTime}
+
+case class Interval(from: LocalDateTime, to: LocalDateTime)
 
 object Dates {
 
-  val localDatePattern = "yyyy-MM-dd"
+  val localDatePattern = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
   private val desDataInceptionDate = LocalDate.parse("2013-03-31")
 
-  def toFormattedLocalDate(date: DateTime) =
-    date.toLocalDate.toString(localDatePattern)
+  def toFormattedLocalDate(date: LocalDateTime) = localDatePattern.format(date)
 
   def toInterval(fromDate: LocalDate, toDate: LocalDate): Interval =
     if (fromDate.isBefore(desDataInceptionDate))
       throw new ValidationException("fromDate earlier than 31st March 2013")
     else
-      new Interval(fromDate.toDate.getTime, toDate.toDateTimeAtStartOfDay.plusMillis(1).toDate.getTime)
+      Interval(fromDate.atTime(LocalTime.MIN), toDate.atTime(0, 0, 0, 1000000))
 }

--- a/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/IntervalQueryStringBinder.scala
+++ b/app/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/IntervalQueryStringBinder.scala
@@ -16,22 +16,22 @@
 
 package uk.gov.hmrc.individualsbenefitsandcreditsapi.utils
 
-import org.joda.time.format.DateTimeFormat
-import org.joda.time.{Interval, LocalDate}
 import play.api.mvc.QueryStringBindable
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.ValidationException
-import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Dates.toInterval
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Dates.{localDatePattern, toInterval}
+
+import java.time.LocalDate
 
 class IntervalQueryStringBinder extends QueryStringBindable[Interval] {
 
-  private val dateTimeFormatter =
-    DateTimeFormat.forPattern(Dates.localDatePattern)
+  private val dateTimeFormatter = Dates.localDatePattern
 
   override def bind(key: String, params: Map[String, Seq[String]]): Option[Either[String, Interval]] =
     (getParam(params, "fromDate"), getParam(params, "toDate", Some(LocalDate.now()))) match {
-      case (Right(from), Right(to)) => Some(interval(from, to))
-      case (_, Left(msg))           => Some(Left(msg))
-      case (Left(msg), _)           => Some(Left(msg))
+      case (Right(from), Right(to)) if to.isBefore(from) => Some(Left("Invalid time period requested"))
+      case (Right(from), Right(to))                      => Some(interval(from, to))
+      case (_, Left(msg))                                => Some(Left(msg))
+      case (Left(msg), _)                                => Some(Left(msg))
     }
 
   private def interval(fromDate: LocalDate, toDate: LocalDate): Either[String, Interval] =
@@ -48,7 +48,7 @@ class IntervalQueryStringBinder extends QueryStringBindable[Interval] {
     default: Option[LocalDate] = None): Either[String, LocalDate] =
     try {
       params.get(paramName).flatMap(_.headOption) match {
-        case Some(date) => Right(dateTimeFormatter.parseLocalDate(date))
+        case Some(date) => Right(LocalDate.parse(date, localDatePattern))
         case None =>
           default.map(Right(_)).getOrElse(Left(s"$paramName is required"))
       }
@@ -57,7 +57,6 @@ class IntervalQueryStringBinder extends QueryStringBindable[Interval] {
     }
 
   override def unbind(key: String, dateRange: Interval): String =
-    s"fromDate=${dateTimeFormatter.print(dateRange.getStart.toLocalDate)}&toDate=${dateTimeFormatter
-      .print(dateRange.getEnd.toLocalDate)}"
+    s"fromDate=${dateTimeFormatter.format(dateRange.from.toLocalDate)}&toDate=${dateTimeFormatter.format(dateRange.to.toLocalDate)}"
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val microservice =
     .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
     .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
     .settings(CodeCoverageSettings.settings *)
-    .settings(scalaVersion := "2.13.8")
+    .settings(scalaVersion := "2.13.12")
     .settings(scalafmtOnCompile := true)
     .settings(onLoadMessage := "")
     .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ import uk.gov.hmrc.DefaultBuildSettings.addTestReportOption
 val appName = "individuals-benefits-and-credits-api"
 
 lazy val ComponentTest = config("component") extend Test
+lazy val ItTest = config("it") extend Test
 
 lazy val microservice =
   Project(appName, file("."))
@@ -21,19 +22,19 @@ lazy val microservice =
       routesImport := Seq("uk.gov.hmrc.individualsbenefitsandcreditsapi.Binders._")
     )
     .settings(Compile / unmanagedResourceDirectories += baseDirectory.value / "resources")
-    .configs(IntegrationTest)
-    .settings(inConfig(IntegrationTest)(Defaults.itSettings) *)
+    .configs(ItTest)
+    .settings(inConfig(ItTest)(Defaults.testSettings) *)
     .settings(
-      IntegrationTest / Keys.fork := false,
-      IntegrationTest / unmanagedSourceDirectories := (IntegrationTest / baseDirectory)(base => Seq(base / "test")).value,
-      IntegrationTest / testOptions := Seq(Tests.Filter((name: String) => name startsWith "it")),
-      addTestReportOption(IntegrationTest, "int-test-reports"),
-      IntegrationTest / testGrouping := oneForkedJvmPerTest((IntegrationTest / definedTests).value),
-      IntegrationTest / parallelExecution := false,
+      ItTest / Keys.fork := false,
+      ItTest / unmanagedSourceDirectories := (ItTest / baseDirectory)(base => Seq(base / "test")).value,
+      ItTest / testOptions := Seq(Tests.Filter((name: String) => name startsWith "it")),
+      addTestReportOption(ItTest, "int-test-reports"),
+      ItTest / testGrouping := oneForkedJvmPerTest((ItTest / definedTests).value),
+      ItTest / parallelExecution := false,
       // Disable default sbt Test options (might change with new versions of bootstrap)
-      IntegrationTest / testOptions -= Tests
+      ItTest / testOptions -= Tests
         .Argument("-o", "-u", "target/int-test-reports", "-h", "target/int-test-reports/html-report"),
-      IntegrationTest / testOptions += Tests.Argument(
+      ItTest / testOptions += Tests.Argument(
         TestFrameworks.ScalaTest,
         "-oNCHPQR",
         "-u",

--- a/conf/app_version_1_0.routes
+++ b/conf/app_version_1_0.routes
@@ -1,3 +1,3 @@
-GET        /working-tax-credit      uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.WorkingTaxCreditController.workingTaxCredit(matchId: java.util.UUID, interval: org.joda.time.Interval)
-GET        /child-tax-credit        uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.ChildTaxCreditController.childTaxCredit(matchId: java.util.UUID, interval: org.joda.time.Interval)
+GET        /working-tax-credit      uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.WorkingTaxCreditController.workingTaxCredit(matchId: java.util.UUID, interval: uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval)
+GET        /child-tax-credit        uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.ChildTaxCreditController.childTaxCredit(matchId: java.util.UUID, interval: uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval)
 GET        /                        uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.RootController.root(matchId: java.util.UUID)

--- a/conf/prod.routes
+++ b/conf/prod.routes
@@ -3,4 +3,3 @@
 ->         /                                                    definition.Routes
 ->         /                                                    health.Routes
 
-GET        /admin/metrics                                       com.kenshoo.play.metrics.MetricsController.metrics

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,23 +5,25 @@ object AppDependencies {
 
   val hmrc = "uk.gov.hmrc"
   val hmrcMongo = s"$hmrc.mongo"
-  val hmrcMongoVersion = "1.4.0"
-  val hmrcBootstrapVersion = "7.23.0"
+  val playVersion = "play-30"
+  val hmrcBootstrapVersion = "8.4.0"
+  val hmrcMongoVersion = "1.7.0"
+
 
   val compile: Seq[ModuleID] = Seq(
     ws,
-    hmrc                %% "bootstrap-backend-play-28"  % hmrcBootstrapVersion,
-    hmrc                %% "domain"                     % "8.3.0-play-28",
-    hmrc                %% "play-hal"                   % "3.4.0-play-28",
-    hmrc                %% "json-encryption"            % "5.2.0-play-28",
-    hmrcMongo           %% "hmrc-mongo-play-28"         % hmrcMongoVersion
+    hmrc                %% s"bootstrap-backend-$playVersion"      % hmrcBootstrapVersion,
+    hmrc                %% s"domain-$playVersion"                 % "9.0.0",
+    hmrc                %% s"play-hal-$playVersion"               % "4.0.0",
+    hmrc                %% s"crypto-json-$playVersion"            % "7.6.0",
+    hmrcMongo           %% s"hmrc-mongo-$playVersion"             % hmrcMongoVersion
   )
 
   def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-    "org.scalatestplus"      %% "mockito-3-4"              % "3.2.1.0"            % scope,
-    "org.scalatestplus"      %% "scalacheck-1-17"          % "3.2.16.0"           % scope,
-    "com.vladsch.flexmark"   % "flexmark-all"              % "0.64.6"            % scope,
-    "org.scalaj"             %% "scalaj-http"              % "2.4.2"              % scope,
-    hmrc                     %% "bootstrap-test-play-28"   % hmrcBootstrapVersion % scope,
+    "org.scalatestplus"      %% "mockito-3-4"                     % "3.2.10.0"            % scope,
+    "org.scalatestplus"      %% "scalacheck-1-17"                 % "3.2.17.0"            % scope,
+    "com.vladsch.flexmark"   % "flexmark-all"                     % "0.64.8"              % scope,
+    "org.scalaj"             %% "scalaj-http"                     % "2.4.2"               % scope,
+    hmrc                     %% s"bootstrap-test-$playVersion"    % hmrcBootstrapVersion  % scope,
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.9.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,10 +4,10 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc" %% "sbt-auto-build" % "3.20.0")
 
-addSbtPlugin("uk.gov.hmrc" %% "sbt-distributables" % "2.2.0")
+addSbtPlugin("uk.gov.hmrc" %% "sbt-distributables" % "2.5.0")
 
-addSbtPlugin("com.typesafe.play" %% "sbt-plugin" % "2.8.20")
+addSbtPlugin("org.playframework" %% "sbt-plugin" % "3.0.1")
 
-addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "1.9.3")
+addSbtPlugin("org.scoverage" %% "sbt-scoverage" % "2.0.10")
 
 addSbtPlugin("com.lucidchart" %% "sbt-scalafmt" % "1.16")

--- a/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnectorSpec.scala
@@ -89,7 +89,7 @@ class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with TestHelpers 
 
     val startDate = "2016-01-01"
     val endDate = "2017-03-01"
-    val interval = toInterval(startDate, endDate)
+    val interval = toInterval(s"${startDate}T00:00:00.000", s"${endDate}T00:00:00.000")
     val nino = Nino("NA000799C")
 
     "Fail when IF returns an error" in new Setup {

--- a/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/connectors/IfConnectorSpec.scala
@@ -65,7 +65,7 @@ class IfConnectorSpec extends SpecBase with BeforeAndAfterEach with TestHelpers 
     val sampleCorrelationId = "188e9400-b636-4a3b-80ba-230a8c72b92a"
     val sampleCorrelationIdHeader = ("CorrelationId" -> sampleCorrelationId)
 
-    implicit val hc = HeaderCarrier()
+    implicit val hc: HeaderCarrier = HeaderCarrier()
 
     val config = fakeApplication.injector.instanceOf[ServicesConfig]
     val httpClient = fakeApplication.injector.instanceOf[HttpClient]

--- a/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/CacheServiceSpec.scala
+++ b/test/it/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/CacheServiceSpec.scala
@@ -30,7 +30,7 @@ import scala.concurrent.Future
 
 class CacheServiceSpec extends AnyFreeSpec with Matchers with ScalaFutures with OptionValues with IntegrationPatience {
 
-  implicit val hc = HeaderCarrier()
+  implicit val hc: HeaderCarrier = HeaderCarrier()
 
   "cache service" - {
 

--- a/test/testUtils/TestDates.scala
+++ b/test/testUtils/TestDates.scala
@@ -16,6 +16,9 @@
 
 package testUtils
 
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
+
+import java.time.LocalDateTime
 import java.time.LocalDateTime.parse
 
 trait TestDates {
@@ -24,6 +27,6 @@ trait TestDates {
     toInterval(parse(fromDate), parse(toDate))
 
   protected def toInterval(fromDate: LocalDateTime, toDate: LocalDateTime): Interval =
-    new Interval(fromDate.toDate.getTime, toDate.toDate.getTime)
+    Interval(fromDate, toDate)
 
 }

--- a/test/testUtils/TestDates.scala
+++ b/test/testUtils/TestDates.scala
@@ -16,8 +16,7 @@
 
 package testUtils
 
-import org.joda.time.LocalDateTime.parse
-import org.joda.time.{Interval, LocalDateTime}
+import java.time.LocalDateTime.parse
 
 trait TestDates {
 

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditControllerSpec.scala
@@ -17,7 +17,6 @@
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
 import akka.stream.Materializer
-import org.joda.time.{Interval, LocalDate}
 import org.mockito.ArgumentMatchers.{any, refEq, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, verifyNoInteractions, when}
@@ -32,9 +31,11 @@ import uk.gov.hmrc.individualsbenefitsandcreditsapi.audit.AuditHelper
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.ChildTaxCreditController
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.MatchNotFoundException
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.{ScopesService, TaxCreditsService}
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.DomainHelpers
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.SpecBase
 
+import java.time.{LocalDate, LocalDateTime, LocalTime}
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -50,9 +51,9 @@ class ChildTaxCreditControllerSpec extends SpecBase with MockitoSugar with Domai
 
   private val testMatchId =
     UUID.fromString("be2dbba5-f650-47cf-9753-91cdaeb16ebe")
-  private val fromDate = new LocalDate("2017-03-02").toDateTimeAtStartOfDay
-  private val toDate = new LocalDate("2017-05-31").toDateTimeAtStartOfDay
-  private val testInterval = new Interval(fromDate, toDate)
+  private val fromDate = new LocalDateTime(LocalDate.parse("2017-03-02"), LocalTime.MIN)
+  private val toDate = new LocalDateTime(LocalDate.parse("2017-05-31"), LocalTime.MAX)
+  private val testInterval = Interval(fromDate, toDate)
 
   trait Fixture {
 

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.{any, refEq, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, verifyNoInteractions, when}

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/ChildTaxCreditControllerSpec.scala
@@ -35,7 +35,7 @@ import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.DomainHelpers
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.SpecBase
 
-import java.time.{LocalDate, LocalDateTime, LocalTime}
+import java.time.{LocalDate, LocalTime}
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -51,8 +51,8 @@ class ChildTaxCreditControllerSpec extends SpecBase with MockitoSugar with Domai
 
   private val testMatchId =
     UUID.fromString("be2dbba5-f650-47cf-9753-91cdaeb16ebe")
-  private val fromDate = new LocalDateTime(LocalDate.parse("2017-03-02"), LocalTime.MIN)
-  private val toDate = new LocalDateTime(LocalDate.parse("2017-05-31"), LocalTime.MAX)
+  private val fromDate = LocalDate.parse("2017-03-02").atStartOfDay()
+  private val toDate = LocalDate.parse("2017-05-31").atTime(LocalTime.MAX)
   private val testInterval = Interval(fromDate, toDate)
 
   trait Fixture {

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/RootControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/RootControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.{any, refEq, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, verifyNoInteractions, when}

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditControllerSpec.scala
@@ -32,9 +32,11 @@ import uk.gov.hmrc.individualsbenefitsandcreditsapi.audit.AuditHelper
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers.WorkingTaxCreditController
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.MatchNotFoundException
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.{ScopesService, TaxCreditsService}
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.DomainHelpers
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.SpecBase
 
+import java.time.LocalDate
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -46,9 +48,9 @@ class WorkingTaxCreditControllerSpec extends SpecBase with MockitoSugar with Dom
   implicit lazy val materializer: Materializer = fakeApplication.materializer
   private val testMatchId =
     UUID.fromString("be2dbba5-f650-47cf-9753-91cdaeb16ebe")
-  private val fromDate = new LocalDate("2017-03-02").toDateTimeAtStartOfDay
-  private val toDate = new LocalDate("2017-05-31").toDateTimeAtStartOfDay
-  private val testInterval = new Interval(fromDate, toDate)
+  private val fromDate = LocalDate.parse("2017-03-02").atStartOfDay()
+  private val toDate = LocalDate.parse("2017-05-31").atStartOfDay()
+  private val testInterval = Interval(fromDate, toDate)
 
   trait Fixture {
 

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditControllerSpec.scala
@@ -17,7 +17,6 @@
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
 import akka.stream.Materializer
-import org.joda.time.{Interval, LocalDate}
 import org.mockito.ArgumentMatchers.{any, refEq, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, verifyNoInteractions, when}

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/controllers/WorkingTaxCreditControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.controllers
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import org.mockito.ArgumentMatchers.{any, refEq, eq => eqTo}
 import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, verifyNoInteractions, when}

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/DomainHelpers.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/DomainHelpers.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits.{CtcApplication, CtcAward, CtcChildTaxCredit, CtcPayment}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.{IfAward, IfChildTaxCredit, IfPayment, IfWorkTaxCredit}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits._

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/childtaxcredits/CtcAwardSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/childtaxcredits/CtcAwardSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.childtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits.CtcAward
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfAward
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.DomainHelpers

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/childtaxcredits/CtcPaymentSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/childtaxcredits/CtcPaymentSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.childtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits.CtcPayment
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfPayment
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.UnitSpec

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/workingtaxcredits/WtcAwardSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/workingtaxcredits/WtcAwardSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.workingtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfAward
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits.WtcAward
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.DomainHelpers

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/workingtaxcredits/WtcPaymentSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/domain/workingtaxcredits/WtcPaymentSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.domain.workingtaxcredits
 
-import org.joda.time.LocalDate
+import java.time.LocalDate
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.integrationframework.IfPayment
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits.WtcPayment
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.UnitSpec

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/LiveTaxCreditsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/LiveTaxCreditsServiceSpec.scala
@@ -30,8 +30,10 @@ import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.childtaxcredits.CtcA
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.domains.workingtaxcredits.WtcApplication
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.cache.{CacheIdBase, CacheService}
 import uk.gov.hmrc.individualsbenefitsandcreditsapi.services.{ScopesHelper, ScopesService, TaxCreditsService}
+import uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.Interval
 import unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils.UnitSpec
 
+import java.time.LocalDate
 import java.util.UUID
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
@@ -60,9 +62,9 @@ class LiveTaxCreditsServiceSpec extends UnitSpec with MockitoSugar with TestHelp
       )
 
     val nino: Nino = Nino("AB123456C")
-    private val fromDate = new LocalDate("2017-03-02").toDateTimeAtStartOfDay
-    private val toDate = new LocalDate("2017-05-31").toDateTimeAtStartOfDay
-    val testInterval = new Interval(fromDate, toDate)
+    private val fromDate = LocalDate.parse("2017-03-02").atStartOfDay()
+    private val toDate = LocalDate.parse("2017-05-31").atStartOfDay()
+    val testInterval = Interval(fromDate, toDate)
     val testMatchId: UUID =
       UUID.fromString("be2dbba5-f650-47cf-9753-91cdaeb16ebe")
 

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/LiveTaxCreditsServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/services/LiveTaxCreditsServiceSpec.scala
@@ -16,7 +16,6 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.services
 
-import org.joda.time.{Interval, LocalDate}
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
 import org.scalatestplus.mockito.MockitoSugar

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/IntervalQueryStringBinderSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/IntervalQueryStringBinderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils
 
-import java.time.LocalDateTime
+import java.time.LocalDate
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -50,7 +50,7 @@ class IntervalQueryStringBinderSpec extends AnyFlatSpec with Matchers with Eithe
     val parameters = Map("fromDate" -> Seq("2017-01-31"))
     val maybeEither = intervalQueryStringBinder.bind("", parameters)
     maybeEither shouldBe Some(
-      Right(toInterval("2017-01-31T00:00:00.000", LocalDateTime.now().withTime(0, 0, 0, 1).toString())))
+      Right(toInterval("2017-01-31T00:00:00.000", LocalDate.now.atTime(0, 0, 0, 1000000).toString)))
   }
 
   it should "succeed in binding an interval from well formed fromDate and toDate parameters" in {
@@ -86,7 +86,7 @@ class IntervalQueryStringBinderSpec extends AnyFlatSpec with Matchers with Eithe
   }
 
   it should "unbind intervals to query parameters" in {
-    val interval = toInterval("2020-01-31", "2020-12-31")
+    val interval = toInterval("2020-01-31T00:00:00.000", "2020-12-31T00:00:00.000")
     intervalQueryStringBinder.unbind("", interval) shouldBe "fromDate=2020-01-31&toDate=2020-12-31"
   }
 

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/IntervalQueryStringBinderSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/IntervalQueryStringBinderSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils
 
-import org.joda.time.LocalDateTime
+import java.time.LocalDateTime
 import org.scalatest.EitherValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/TestSupport.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/TestSupport.scala
@@ -16,8 +16,8 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.inject.guice.GuiceableModule

--- a/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/UnitSpec.scala
+++ b/test/unit/uk/gov/hmrc/individualsbenefitsandcreditsapi/utils/UnitSpec.scala
@@ -16,8 +16,8 @@
 
 package unit.uk.gov.hmrc.individualsbenefitsandcreditsapi.utils
 
-import akka.stream.Materializer
-import akka.util.ByteString
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.util.ByteString
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.inject.guice.GuiceableModule


### PR DESCRIPTION
| [DLS-10099](https://jira.tools.tax.service.gov.uk/browse/DLS-10099) |

- [x] Upgrade of scalaVersion on 2.13.12
- [x] Upgrade of sbt.version to 1.9.7
- [x] Updated dependencies that include play-28 in their name, replacing play-28  with play-30 and use the latest version of the library
- [x] Replaced akka dependency with pekko.
- [x] Dropped kenshoo play-metrics dependency 
- [x] Replaced deprecated`IntegrationTest` 
- [x] Refactor for crypto-json library
- [x] Replaced Joda with Java time (migration from joda.time interval)
- [x] Updated tests after migration to java.time


Additional explanation of some of the changes:

- Joda.time operates on the milliseconds, while Java.time uses nanoseconds. Most of the failing tests were failing because of this thus LocalDate.now.atTime(0, 0, 0, 1) had to be converted to LocalDate.now.atTime(0, 0, 0, 1000000).

- It seems that the Interval introduced by Joda.time covered the scenario of the Invalid time period requested, where the toDate is before the fromDate (example: fromDate = 2020-01-31 while toDate = 2020-12-31).
The Interval implemented via the case class does not do that thus the right case in the bind method in the IntervalQueryStringBinder.scala was added to cover that "Invalid time period" scenario.